### PR TITLE
Make it compile again after AVStream::codec deprecation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ Makefile.in
 Makefile
 aclocal.m4
 autom4te.cache/
+compile
 config.guess
 config.h.in
 config.rpath
@@ -33,5 +34,6 @@ po/POTFILES
 po/*.gmo
 po/stamp-po
 stamp-h1
+tagutils/.dirstamp
 .deps/
 *.o

--- a/inotify.c
+++ b/inotify.c
@@ -165,7 +165,7 @@ inotify_create_watches(int fd)
 		num_watches++;
 	}
 	sqlite3_free_table(result);
-		
+
 	max_watches = fopen("/proc/sys/fs/inotify/max_user_watches", "r");
 	if( max_watches )
 	{
@@ -208,7 +208,7 @@ inotify_create_watches(int fd)
 	return rows;
 }
 
-int 
+int
 inotify_remove_watches(int fd)
 {
 	struct watch *w = watches;
@@ -352,7 +352,7 @@ inotify_insert_file(char * name, const char * path)
 			return -1;
 			break;
 	}
-	
+
 	/* If it's already in the database and hasn't been modified, skip it. */
 	if( stat(path, &st) != 0 )
 		return -1;
@@ -649,7 +649,7 @@ start_inotify()
 	int length, i = 0;
 	char * esc_name = NULL;
 	struct stat st;
-        
+
 	pollfds[0].fd = inotify_init();
 	pollfds[0].events = POLLIN;
 
@@ -666,8 +666,7 @@ start_inotify()
 	if (setpriority(PRIO_PROCESS, 0, 19) == -1)
 		DPRINTF(E_WARN, L_INOTIFY,  "Failed to reduce inotify thread priority\n");
 	sqlite3_release_memory(1<<31);
-	av_register_all();
-        
+
 	while( !quitting )
 	{
                 length = poll(pollfds, 1, timeout);

--- a/libav.h
+++ b/libav.h
@@ -169,7 +169,7 @@ lav_is_thumbnail_stream(AVStream *s, uint8_t **data, int *size)
 {
 #if LIBAVFORMAT_VERSION_INT >= ((54<<16)+(6<<8))
 	if (s->disposition & AV_DISPOSITION_ATTACHED_PIC &&
-	    s->codec->codec_id == AV_CODEC_ID_MJPEG)
+	    s->codecpar->codec_id == AV_CODEC_ID_MJPEG)
 	{
 		if (data)
 			*data = s->attached_pic.data;

--- a/metadata.c
+++ b/metadata.c
@@ -596,7 +596,7 @@ GetVideoMetadata(const char *path, char *name)
 	int ret, i;
 	struct tm *modtime;
 	AVFormatContext *ctx = NULL;
-	AVCodecContext *ac = NULL, *vc = NULL;
+	AVCodecParameters *ac = NULL, *vc = NULL;
 	int audio_stream = -1, video_stream = -1;
 	char fourcc[4];
 	int64_t album_art = 0;
@@ -629,18 +629,18 @@ GetVideoMetadata(const char *path, char *name)
 	for( i=0; i<ctx->nb_streams; i++)
 	{
 		if( audio_stream == -1 &&
-		    ctx->streams[i]->codec->codec_type == AVMEDIA_TYPE_AUDIO )
+		    ctx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO )
 		{
 			audio_stream = i;
-			ac = ctx->streams[audio_stream]->codec;
+			ac = ctx->streams[audio_stream]->codecpar;
 			continue;
 		}
 		else if( video_stream == -1 &&
 		         !lav_is_thumbnail_stream(ctx->streams[i], &m.thumb_data, &m.thumb_size) &&
-			 ctx->streams[i]->codec->codec_type == AVMEDIA_TYPE_VIDEO )
+			 ctx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO )
 		{
 			video_stream = i;
-			vc = ctx->streams[video_stream]->codec;
+			vc = ctx->streams[video_stream]->codecpar;
 			continue;
 		}
 	}

--- a/minidlna.c
+++ b/minidlna.c
@@ -101,7 +101,7 @@
 # warning "Your SQLite3 library appears to be too old!  Please use 3.5.1 or newer."
 # define sqlite3_threadsafe() 0
 #endif
- 
+
 /* OpenAndConfHTTPSocket() :
  * setup the socket used to handle incoming HTTP connections. */
 static int
@@ -146,7 +146,7 @@ OpenAndConfHTTPSocket(unsigned short port)
 	return s;
 }
 
-/* Handler for the SIGTERM signal (kill) 
+/* Handler for the SIGTERM signal (kill)
  * SIGINT is also handled */
 static void
 sigterm(int sig)
@@ -206,10 +206,10 @@ transcode_getclient(struct client_type_s *clients, char *str, char **ret_str)
 	{
 		formats = str;
 	}
-	
+
 	/* move the beginning of str */
 	*ret_str = formats;
-	
+
 	if( ! clients[client->type].transcode_info )
 	{
 		/* create a new entry for client in the transcode list */
@@ -352,6 +352,7 @@ open_db(sqlite3 **sq3)
 		new_db = 1;
 		make_dir(db_path, S_ISVTX|S_IRWXU|S_IRWXG|S_IRWXO);
 	}
+	DPRINTF(E_WARN, L_GENERAL, "Opening sqlite database %s\n", path);
 	if (sqlite3_open(path, &db) != SQLITE_OK)
 		DPRINTF(E_FATAL, L_GENERAL, "ERROR: Failed to open sqlite database!  Exiting...\n");
 	if (sq3)
@@ -492,7 +493,7 @@ writepidfile(const char *fname, int pid, uid_t uid)
 					dir, strerror(errno));
 		}
 	}
-	
+
 	pidfile = fopen(fname, "w");
 	if (!pidfile)
 	{
@@ -503,7 +504,7 @@ writepidfile(const char *fname, int pid, uid_t uid)
 
 	if (fprintf(pidfile, "%d\n", pid) <= 0)
 	{
-		DPRINTF(E_ERROR, L_GENERAL, 
+		DPRINTF(E_ERROR, L_GENERAL,
 			"Unable to write to pidfile %s: %s\n", fname, strerror(errno));
 		ret = -1;
 	}
@@ -588,7 +589,7 @@ init(int argc, char **argv)
 	strncat(uuidvalue, mac_str, 12);
 
 	getfriendlyname(friendly_name, FRIENDLYNAME_MAX_LEN);
-	
+
 	runtime_vars.port = 8200;
 	runtime_vars.notify_interval = 895;	/* seconds between SSDP announces */
 	runtime_vars.max_connections = 50;
@@ -631,7 +632,7 @@ init(int argc, char **argv)
 			break;
 		case UPNPSERIAL:
 			strncpyt(serialnumber, ary_options[i].value, SERIALNUMBER_MAX_LEN);
-			break;				
+			break;
 		case UPNPMODEL_NAME:
 			strncpyt(modelname, ary_options[i].value, MODELNAME_MAX_LEN);
 			break;
@@ -1029,7 +1030,7 @@ init(int argc, char **argv)
 	{
 		DPRINTF(E_ERROR, L_GENERAL, SERVER_NAME " is already running. EXITING.\n");
 		return 1;
-	}	
+	}
 
 	set_startup_time();
 
@@ -1251,25 +1252,25 @@ main(int argc, char **argv)
 		/* select open sockets (SSDP, HTTP listen, and all HTTP soap sockets) */
 		FD_ZERO(&readset);
 
-		if (sssdp >= 0) 
+		if (sssdp >= 0)
 		{
 			FD_SET(sssdp, &readset);
 			max_fd = MAX(max_fd, sssdp);
 		}
-		
-		if (shttpl >= 0) 
+
+		if (shttpl >= 0)
 		{
 			FD_SET(shttpl, &readset);
 			max_fd = MAX(max_fd, shttpl);
 		}
 #ifdef TIVO_SUPPORT
-		if (sbeacon >= 0) 
+		if (sbeacon >= 0)
 		{
 			FD_SET(sbeacon, &readset);
 			max_fd = MAX(max_fd, sbeacon);
 		}
 #endif
-		if (smonitor >= 0) 
+		if (smonitor >= 0)
 		{
 			FD_SET(smonitor, &readset);
 			max_fd = MAX(max_fd, smonitor);
@@ -1411,7 +1412,7 @@ shutdown:
 	if (sbeacon >= 0)
 		close(sbeacon);
 #endif
-	
+
 	for (i = 0; i < n_lan_addr; i++)
 	{
 		SendSSDPGoodbyes(lan_addr[i].snotify);

--- a/scanner.c
+++ b/scanner.c
@@ -846,7 +846,6 @@ start_scanner()
 
 	setlocale(LC_COLLATE, "");
 
-	av_register_all();
 	av_log_set_level(AV_LOG_PANIC);
 	for( media_path = media_dirs; media_path != NULL; media_path = media_path->next )
 	{
@@ -878,7 +877,7 @@ start_scanner()
 
 	if( GETFLAG(NO_PLAYLIST_MASK) )
 	{
-		DPRINTF(E_WARN, L_SCANNER, "Playlist creation disabled\n");	  
+		DPRINTF(E_WARN, L_SCANNER, "Playlist creation disabled\n");
 	}
 	else
 	{

--- a/transcode.c
+++ b/transcode.c
@@ -173,14 +173,13 @@ needs_transcode_audio(const char* path, enum client_types client)
 {
 	int ret;
 	AVFormatContext *ctx = NULL;
-	struct AVCodecContext *ac = NULL;
+	struct AVCodecParameters *ac = NULL;
 	int i;
 	struct transcode_list_format_s *transcode_format_it = NULL;
-	struct AVCodec *codec = NULL;
+	const struct AVCodec *codec = NULL;
 	struct transcode_info_s *clients_info[] = {client_types[0].transcode_info, client_types[client].transcode_info};
 
 	/* prepare ffmpeg */
-	av_register_all();
 	ret = lav_open(&ctx, path);
 	if( ret != 0 )
 	{
@@ -191,18 +190,18 @@ needs_transcode_audio(const char* path, enum client_types client)
 	}
 	for( i=0; i<ctx->nb_streams; i++)
 	{
-		if( ctx->streams[i]->codec->codec_type == AVMEDIA_TYPE_AUDIO )
+		if( ctx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO )
 		{
-			ac = ctx->streams[i]->codec;
+			ac = ctx->streams[i]->codecpar;
 			break;
 		}
 	}
 	if ( ac )
 	{
 		codec = avcodec_find_decoder(ac->codec_id);
-		
+
 		for ( i = 0; i < 2; i++ )
-		{	
+		{
 			if (clients_info[i])
 			{
 				transcode_format_it = clients_info[i]->audio_codecs;
@@ -235,16 +234,15 @@ needs_transcode_video(const char* path, enum client_types client)
 {
 	int ret;
 	AVFormatContext *ctx = NULL;
-	struct AVCodec *codec = NULL;
+	const struct AVCodec *codec = NULL;
 	int audio_stream = -1, video_stream = -1;
-	struct AVCodecContext *ac = NULL;
-	struct AVCodecContext *vc = NULL;
+	struct AVCodecParameters *ac = NULL;
+	struct AVCodecParameters *vc = NULL;
 	int i;
 	struct transcode_list_format_s *transcode_format_it = NULL;
 	struct transcode_info_s *clients_info[] = {client_types[0].transcode_info, client_types[client].transcode_info};
 
 	/* prepare ffmpeg */
-	av_register_all();
 	ret = lav_open(&ctx, path);
 	if( ret != 0 )
 	{
@@ -256,17 +254,17 @@ needs_transcode_video(const char* path, enum client_types client)
 	for( i=0; i<ctx->nb_streams; i++)
 	{
 		if( audio_stream == -1 &&
-			ctx->streams[i]->codec->codec_type == AVMEDIA_TYPE_AUDIO )
+			ctx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO )
 		{
 			audio_stream = i;
-			ac = ctx->streams[audio_stream]->codec;
+			ac = ctx->streams[audio_stream]->codecpar;
 			continue;
 		}
 		else if( video_stream == -1 &&
-			ctx->streams[i]->codec->codec_type == AVMEDIA_TYPE_VIDEO )
+			ctx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO )
 		{
 			video_stream = i;
-			vc = ctx->streams[video_stream]->codec;
+			vc = ctx->streams[video_stream]->codecpar;
 			continue;
 		}
 	}
@@ -317,7 +315,7 @@ needs_transcode_video(const char* path, enum client_types client)
 				lav_close(ctx);
 				return 1;
 			}
-			
+
 			codec = avcodec_find_decoder(vc->codec_id);
 			while( transcode_format_it )
 			{
@@ -330,7 +328,7 @@ needs_transcode_video(const char* path, enum client_types client)
 			}
 		}
 	}
-	
+
 	/* check the audio codec */
 	for ( i = 0; i < 2; i++ )
 	{

--- a/upnphttp.c
+++ b/upnphttp.c
@@ -111,7 +111,7 @@ static void SendResp_resizedimg(struct upnphttp *, char * url);
 static void SendResp_thumbnail(struct upnphttp *, char * url);
 static void SendResp_dlnafile(struct upnphttp *, char * url);
 
-struct upnphttp * 
+struct upnphttp *
 New_upnphttp(int s)
 {
 	struct upnphttp * ret;
@@ -562,7 +562,7 @@ Send416(struct upnphttp * h)
 void
 Send500(struct upnphttp * h)
 {
-	static const char body500[] = 
+	static const char body500[] =
 		"<HTML><HEAD><TITLE>500 Internal Server Error</TITLE></HEAD>"
 		"<BODY><H1>Internal Server Error</H1>Server encountered "
 		"and Internal Error.</BODY></HTML>\r\n";
@@ -577,7 +577,7 @@ Send500(struct upnphttp * h)
 void
 Send501(struct upnphttp * h)
 {
-	static const char body501[] = 
+	static const char body501[] =
 		"<HTML><HEAD><TITLE>501 Not Implemented</TITLE></HEAD>"
 		"<BODY><H1>Not Implemented</H1>The HTTP Method "
 		"is not implemented by this server.</BODY></HTML>\r\n";
@@ -689,7 +689,7 @@ ProcessHTTPPOST_upnphttp(struct upnphttp * h)
 		{
 			/* we can process the request */
 			DPRINTF(E_DEBUG, L_HTTP, "SOAPAction: %.*s\n", h->req_soapActionLen, h->req_soapAction);
-			ExecuteSoapAction(h, 
+			ExecuteSoapAction(h,
 				h->req_soapAction,
 				h->req_soapActionLen);
 		}
@@ -772,7 +772,7 @@ ProcessHTTPSubscribe_upnphttp(struct upnphttp * h, const char * path)
 	if (type == E_SUBSCRIBE)
 	{
 		/* - add to the subscriber list
-		 * - respond HTTP/x.x 200 OK 
+		 * - respond HTTP/x.x 200 OK
 		 * - Send the initial event message */
 		/* Server:, SID:; Timeout: Second-(xx|infinite) */
 		sid = upnpevents_addSubscriber(path, h->req_Callback,
@@ -830,7 +830,7 @@ ProcessHTTPUnSubscribe_upnphttp(struct upnphttp * h, const char * path)
 	CloseSocket_upnphttp(h);
 }
 
-/* Parse and process Http Query 
+/* Parse and process Http Query
  * called once all the HTTP headers have been received. */
 static void
 ProcessHttpQuery_upnphttp(struct upnphttp * h)
@@ -1069,7 +1069,7 @@ ProcessHttpQuery_upnphttp(struct upnphttp * h)
 
 
 void
-Process_upnphttp(struct upnphttp * h)
+Process_upnphttp(struct upnphttp *h)
 {
 	char buf[2048];
 	int n;
@@ -1086,7 +1086,7 @@ Process_upnphttp(struct upnphttp * h)
 		}
 		else if(n==0)
 		{
-			DPRINTF(E_WARN, L_HTTP, "HTTP Connection closed unexpectedly\n");
+			DPRINTF(E_DEBUG, L_HTTP, "HTTP Connection closed unexpectedly\n");
 			h->state = 100;
 		}
 		else
@@ -1273,7 +1273,7 @@ send_data(struct upnphttp * h, char * header, size_t size, int flags)
 	if(n<0)
 	{
 		DPRINTF(E_ERROR, L_HTTP, "send(res_buf): %s\n", strerror(errno));
-	} 
+	}
 	else if(n < h->res_buflen)
 	{
 		/* TODO : handle correctly this case */
@@ -2071,7 +2071,7 @@ SendResp_dlnafile(struct upnphttp *h, char *object)
 				Send500(h);
 				return;
 			}
-			
+
 			close(transcode_handle); /* causes ffmpeg transcoder to exit, TODO: check if this is true for other transcoders, too */
 			if( dlna_metadata.mime == NULL && dlna_metadata.dlna_pn == NULL ) {
 				DPRINTF(E_ERROR, L_HTTP, "Cannot obtain metadata.\n");
@@ -2103,7 +2103,7 @@ SendResp_dlnafile(struct upnphttp *h, char *object)
 				if( strcmp(last_file.mime+6, "x-matroska") == 0 )
 					strcpy(last_file.mime+8, "mkv");
 				/* Samsung TV's such as the A750 can natively support many
-				   Xvid/DivX AVI's however, the DLNA server needs the 
+				   Xvid/DivX AVI's however, the DLNA server needs the
 				   mime type to say video/mpeg */
 				else if( ctype == ESamsungSeriesA && strcmp(last_file.mime+6, "x-msvideo") == 0 )
 					strcpy(last_file.mime+6, "mpeg");
@@ -2119,7 +2119,7 @@ SendResp_dlnafile(struct upnphttp *h, char *object)
 					strcpy(last_file.mime+6, "divx");
 			}
 		}
-		
+
 		sqlite3_free_table(result);
 	}
 #if USE_FORK


### PR DESCRIPTION
This is a proposed set of changes to accommodate removal of AVStream::codec in ffmpeg 4.4.

- Converted AVCodecContext to AVCodecParameters wherever possible. This seems like a straight forward change.

Also -
- Populated the context and used it for rc_max_rate in dlnameta.c.
- Removed av_register_all() calls since it is no longer needed.